### PR TITLE
Remove "X-Google-DKIM-Signature"

### DIFF
--- a/lib/Mail/Milter/Authentication/Handler/DKIM.pm
+++ b/lib/Mail/Milter/Authentication/Handler/DKIM.pm
@@ -46,14 +46,6 @@ sub header_callback {
         $self->{'has_dkim'} = 1;
     }
 
-    # Add Google signatures to the mix.
-    # Is this wise?
-    if ( $header eq 'X-Google-DKIM-Signature' ) {
-        my $x_dkim_chunk = 'DKIM-Signature: ' . $value . $EOL;
-        $x_dkim_chunk =~ s/\015?\012/$EOL/g;
-        push @{$self->{'headers'}} , $x_dkim_chunk;
-        $self->{'has_dkim'} = 1;
-    }
     return;
 }
 


### PR DESCRIPTION
As far as I can see, the `X-Google-DKIM-Signature` header is only used by Google internally. It should not be considered as a public header (it's started with `X-` anyway). A mail with only `X-Google-DKIM-Signature` and without proper `DKIM-Signature` should not be considered DKIM valid.

Ref: https://www.ietf.org/mail-archive/web/apps-discuss/current/msg11956.html