### PR TITLE
drop features that require later-than-specified perl

### DIFF
--- a/lib/Mail/Milter/Authentication.pm
+++ b/lib/Mail/Milter/Authentication.pm
@@ -26,7 +26,7 @@ sub _warn {
     my @parts = split "\n", $msg;
     foreach my $part ( @parts ) {
         next if $part eq q{};
-        print STDERR scalar localtime . ' ' . $Mail::Milter::Authentication::Config::IDENT . "[$PID] $part\n";
+        print STDERR scalar(localtime) . ' ' . $Mail::Milter::Authentication::Config::IDENT . "[$PID] $part\n";
     }
     return;
 }

--- a/lib/Mail/Milter/Authentication/Client.pm
+++ b/lib/Mail/Milter/Authentication/Client.pm
@@ -318,7 +318,7 @@ sub process {
         while ( @process_header ) {
             my $key = shift @process_header;
             my $value = shift @process_header;
-            $value //= '';
+            $value = '' unless defined $value;
             $header_string .= "$key: $value\015\012";
         }
         my $header_obj = Email::Simple::Header->new( $header_string );


### PR DESCRIPTION
The Makefile.PL requires perl v5.6.0, but some code uses the `//` operator, not introduced until v5.10.0.  This replaces it with the uglier pre-5.10 form.  I've also cleaned up a runtime warning I see under v5.8.8.