### PR TITLE
Remap ip/helo as early as possible

### DIFF
--- a/bin/authentication_milter
+++ b/bin/authentication_milter
@@ -340,10 +340,10 @@ __END__
             "ip" : "5.6.7.8", "helo" : "mx.test"        | want to run IP based checks (eg SPF) against its external
                                                         |
             "helo_map" : {                              | Additionally match and remap based on a received HELO host
-                "test.host" : {                         | from a matching IP address, this is done at the HELO stage, ie
-                    "ip" : "5.6.7.9",                   | after the connect stage, so handlers which run in the connect
-                    "helo" : "mx2.test"                 | stage will not see this remapped ip address.
-                }                                       |
+                "test.host" : {                         | from a matching IP address, for milter protocol this is done at the HELO stage, ie
+                    "ip" : "5.6.7.9",                   | after the connect stage, so handlers which run in the connect stage will not see
+                    "helo" : "mx2.test"                 | this remapped ip address. SMTP protocol runs both remaps before passing control to
+                }                                       | the connect handlers, so connect handlers see ip addresses remapped by HELO.
             }
         }                                               | IP address instead.
     },

--- a/lib/Mail/Milter/Authentication/Protocol/Milter.pm
+++ b/lib/Mail/Milter/Authentication/Protocol/Milter.pm
@@ -55,7 +55,8 @@ sub milter_process_command {
 
     if ( $command eq SMFIC_CONNECT ) {
         my ( $host, $ip ) = $self->milter_process_connect( $buffer );
-        $returncode = $handler->top_connect_callback( $host, $ip );
+        $handler->remap_connect_callback( $host, $ip );
+        $returncode = $handler->top_connect_callback( $host, $handler->{'ip_object'} );
     }
     elsif ( $command eq SMFIC_ABORT ) {
         $returncode = $handler->top_abort_callback();
@@ -82,7 +83,8 @@ sub milter_process_command {
     }
     elsif ( $command eq SMFIC_HELO ) {
         my $helo = $self->milter_split_buffer( $buffer );
-        $returncode = $handler->top_helo_callback( @$helo );
+        $handler->remap_helo_callback( @$helo );
+        $returncode = $handler->top_helo_callback( $handler->{'helo_name'} );
     }
     elsif ( $command eq SMFIC_HEADER ) {
         my $header = $self->milter_split_buffer( $buffer );

--- a/lib/Mail/Milter/Authentication/Protocol/SMTP.pm
+++ b/lib/Mail/Milter/Authentication/Protocol/SMTP.pm
@@ -414,10 +414,14 @@ sub smtp_command_mailfrom {
         $ip = substr( $ip, 5 );
     }
 
-    $self->logdebug( "Inbound IP Address $ip" );
-    $returncode = $handler->top_connect_callback( $host, Net::IP->new( $ip ) );
+    # Do connection remapping first
+    $handler->remap_connect_callback( $host, Net::IP->new( $ip ) );
+    $handler->remap_helo_callback( $helo );
+
+    $self->logdebug( "Inbound IP Address " . $handler->{'ip_object'}->ip() );
+    $returncode = $handler->top_connect_callback( $host, $handler->{'ip_object'} );
     if ( $returncode == SMFIS_CONTINUE ) {
-        $returncode = $handler->top_helo_callback( $helo );
+        $returncode = $handler->top_helo_callback( $handler->{'helo_name'} );
         if ( $returncode == SMFIS_CONTINUE ) {
             my $envfrom = command_param( $command,10 );
             $smtp->{'mail_from'} = $envfrom;

--- a/t/04-unit-handler-remap.t
+++ b/t/04-unit-handler-remap.t
@@ -1,0 +1,138 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use lib 't';
+
+use Data::Dumper;
+
+use Mail::Milter::Authentication::Tester::HandlerTester;
+use Mail::Milter::Authentication::Constants qw{ :all };
+use Test::Exception;
+use Test::More;
+use Net::IP;
+use JSON;
+use Clone qw{ clone };
+
+my $basedir = q{};
+
+open( STDERR, '>>', $basedir . 't/tmp/misc.err' ) || die "Cannot open errlog [$!]";
+#open( STDOUT, '>>', $basedir . 't/tmp/misc.err' ) || die "Cannot open errlog [$!]";
+
+my $base_tester = Mail::Milter::Authentication::Tester::HandlerTester->new({
+    'prefix'   => $basedir . 't/config/handler/etc',
+    'zonedata' => '',
+    'handler_config' => {
+        'IPRev' => {},
+        'PTR' => {},
+        'LocalIP' => {},
+        'TrustedIP' => {},
+        'Auth' => {},
+    },
+});
+
+my $no_remap_tester = clone $base_tester;
+my $remap_tester = clone $base_tester;
+$remap_tester->{ 'authmilter' }->{ 'config' }->{ 'ip_map' } = {
+    '1.1.0.0/24' => {
+        'ip' => '1.2.0.1',
+        'helo' => 'ip_remapped.example.com',
+        'helo_map' => {
+            'matched_helo.example.com' => {
+                'ip' => '1.3.0.1',
+                'helo' => 'helo_remapped.example.com',
+            }
+        }
+    }
+};
+my $use_tester;
+
+$use_tester = clone $no_remap_tester;
+subtest no_remap_smtp => sub {
+    run_test_on( $use_tester, 'smtp', '1.4.0.1', 'sent_helo.example.com', '1.4.0.1', 'sent_helo.example.com' );
+};
+
+$use_tester = clone $no_remap_tester;
+subtest no_remap_milter => sub {
+    run_test_on( $use_tester, 'milter', '1.4.0.1', 'sent_helo.example.com', '1.4.0.1', 'sent_helo.example.com' );
+};
+
+$use_tester = clone $remap_tester;
+subtest ip_remap_no_hit_smtp => sub {
+    run_test_on( $use_tester, 'smtp', '1.4.0.1', 'sent_helo.example.com', '1.4.0.1', 'sent_helo.example.com' );
+};
+
+$use_tester = clone $remap_tester;
+subtest ip_remap_no_hit_milter => sub {
+    run_test_on( $use_tester, 'milter', '1.4.0.1', 'sent_helo.example.com', '1.4.0.1', 'sent_helo.example.com' );
+};
+
+$use_tester = clone $remap_tester;
+subtest ip_remap_ip_hit_smtp => sub {
+    run_test_on( $use_tester, 'smtp', '1.1.0.1', 'sent_helo.example.com', '1.2.0.1', 'ip_remapped.example.com' );
+};
+
+$use_tester = clone $remap_tester;
+subtest ip_remap_ip_hit_milter => sub {
+    run_test_on( $use_tester, 'milter', '1.1.0.1', 'sent_helo.example.com', '1.2.0.1', 'ip_remapped.example.com' );
+};
+
+$use_tester = clone $remap_tester;
+subtest ip_remap_helo_hit_smtp => sub {
+    run_test_on( $use_tester, 'smtp', '1.1.0.1', 'matched_helo.example.com', '1.3.0.1', 'helo_remapped.example.com' );
+};
+
+$use_tester = clone $remap_tester;
+subtest ip_remap_helo_hit_milter => sub {
+    # IP cannot remap in milter protocol, so will be the generic remap not the helo remap
+    run_test_on( $use_tester, 'milter', '1.1.0.1', 'matched_helo.example.com', '1.2.0.1', 'helo_remapped.example.com' );
+};
+
+done_testing();
+
+sub run_test_on {
+  my ( $tester, $order, $send_ip, $send_helo, $expect_ip, $expect_helo ) = @_;
+
+  my $host = 'nothing.example.com';
+  my $ip = Net::IP->new( $send_ip );
+  my $helo = $send_helo;
+  my $from = 'from_address.example.com';
+  my $to = 'to_address.example.com';
+
+  my $handler = $tester->{ 'authmilter' }->{ 'handler' }->{ '_Handler' };;
+
+  if ( $order eq 'smtp' ) {
+    $handler->remap_connect_callback( $host, $ip );
+    $handler->remap_helo_callback( $helo );
+    $handler->top_connect_callback( $host, $handler->{ 'ip_object' } );
+    $handler->top_helo_callback( $handler->{ 'helo_name' } );
+  }
+  else {
+    $handler->remap_connect_callback( $host, $ip );
+    $handler->top_connect_callback( $host, $handler->{ 'ip_object' } );
+    $handler->remap_helo_callback( $helo );
+    $handler->top_helo_callback( $handler->{ 'helo_name' } );
+  }
+
+  $handler->top_envfrom_callback( $from );
+  $handler->top_envrcpt_callback( $to );
+
+  $handler->top_header_callback( 'From', $from );
+  $handler->top_header_callback( 'To', $to );
+  $handler->top_header_callback( 'Subuject', 'Testing');
+
+  $handler->top_eoh_callback();
+  $handler->top_body_callback( 'This is a test email' );
+  $handler->top_eom_callback();
+
+  my $iprev_header = $tester->get_authresults_header()->search({ 'key' => 'iprev' });
+  my $ptr_header = $tester->get_authresults_header()->search({ 'key' => 'x-ptr' });
+  my $used_ip = $iprev_header->search({ 'key' => 'smtp.remote-ip' })->children()->[0]->value();
+  my $used_helo = $ptr_header->search({ 'key' => 'smtp.helo' })->children()->[0]->value();
+
+  is( $used_ip, $expect_ip, 'IP is correct' );
+  is( $used_helo, $expect_helo, 'HELO is correct' );
+  $tester->close();
+
+}
+


### PR DESCRIPTION
SMTP protocol will get remapped before a handler connection callback is
made, so all handlers will see the correct remapped information.
This is not possible with Milter protocol.