### PR TITLE
Dmarc report metrics alt

### DIFF
--- a/lib/Mail/Milter/Authentication.pm
+++ b/lib/Mail/Milter/Authentication.pm
@@ -1012,7 +1012,7 @@ sub setup_handler {
     my $object = $package->new( $self );
     $self->{'handler'}->{$name} = $object;
 
-    foreach my $callback ( qw { setup connect helo envfrom envrcpt header eoh body eom addheader abort close } ) {
+    foreach my $callback ( qw { metrics setup connect helo envfrom envrcpt header eoh body eom addheader abort close } ) {
         if ( $object->can( $callback . '_callback' ) ) {
             $self->register_callback( $name, $callback );
         }
@@ -1061,7 +1061,7 @@ Sort the callbacks into the order in which they must be called
 
 sub sort_all_callbacks {
     my ($self) = @_;
-    foreach my $callback ( qw { setup connect helo envfrom envrcpt header eoh body eom addheader abort close } ) {
+    foreach my $callback ( qw { metrics setup connect helo envfrom envrcpt header eoh body eom addheader abort close } ) {
         $self->sort_callbacks( $callback );
     }
     return;

--- a/lib/Mail/Milter/Authentication/Handler.pm
+++ b/lib/Mail/Milter/Authentication/Handler.pm
@@ -123,16 +123,16 @@ Set a metrics counter to $count
 =cut
 
 sub metric_set {
-    my ( $self, $count_id, $labels, $count ) = @_;
+    my ( $self, $gauge_id, $labels, $value ) = @_;
     $labels = {} if ! defined $labels;
-    die 'Must set count in metric_set call' if ! defined $count;
+    die 'Must set value in metric_set call' if ! defined $value;
 
     my $metric = $self->{'thischild'}->{'metric'};
     $metric->set({
-        'count_id' => $count_id,
+        'gauge_id' => $gauge_id,
         'labels'   => $labels,
         'server'   => $self->{'thischild'},
-        'count'    => $count,
+        'value'    => $value,
     });
     return;
 }
@@ -558,6 +558,7 @@ sub top_metrics_callback {
             $self->log_error( 'Metrics callback error ' . $error );
         }
     };
+    return;
 }
 
 =callback_method I<top_connect_callback( $hostname, $ip )>

--- a/lib/Mail/Milter/Authentication/Handler/DMARC.pm
+++ b/lib/Mail/Milter/Authentication/Handler/DMARC.pm
@@ -179,7 +179,7 @@ sub pre_fork_setup {
 sub register_metrics {
     return {
         'dmarc_total' => 'The number of emails processed for DMARC',
-        'dmarc_reports_total' => 'The number of pending DMARC reports',
+        'dmarc_reports_total' => { type => 'gauge', help => 'The number of pending DMARC reports' },
     };
 }
 
@@ -188,12 +188,15 @@ sub metrics_callback {
     my $config = $self->handler_config();
     return if $config->{'no_report'};
 
-    my $time = time;
-    my $backend = Mail::DMARC::Report::Store->new()->backend;
-    my $queued_result = $backend->query("SELECT COUNT(*) AS c FROM report WHERE end >= $time");
-    my $pending_result = $backend->query("SELECT COUNT(*) AS c FROM report WHERE end < $time");
-    $self->metric_set( 'dmarc_reports_total', { 'state' => 'queued' }, $queued_result->{c} );
-    $self->metric_set( 'dmarc_reports_total', { 'state' => 'pending' }, $pending_result->{c} );
+    eval {
+        my $time = time;
+        my $backend = Mail::DMARC::Report::Store->new()->backend;
+        my $current = $backend->query("SELECT COUNT(1) AS c FROM report WHERE end >= $time")->[0]->{c};
+        my $pending = $backend->query("SELECT COUNT(1) AS c FROM report WHERE end < $time")->[0]->{c};
+        $self->metric_set( 'dmarc_reports_total', { 'state' => 'current' }, $current );
+        $self->metric_set( 'dmarc_reports_total', { 'state' => 'pending' }, $pending );
+    };
+
     return;
 }
 

--- a/lib/Mail/Milter/Authentication/Metric.pm
+++ b/lib/Mail/Milter/Authentication/Metric.pm
@@ -128,6 +128,50 @@ sub count {
     return;
 }
 
+=method I<set($args)>
+
+Set the metric for the given counter
+Called from the base handler, do not call directly.
+$server is the current handler object
+
+ count_id - the name of the metric to act on
+
+ labels - hashref of labels to apply
+
+ server - the current server object
+
+ count - number to increment by (defaults to 1)
+
+=cut
+
+sub set {
+    my ( $self, $args ) = @_;
+    return if ( ! $self->{ 'enabled' } );
+
+    my $count_id = $args->{ 'count_id' };
+    my $labels   = $args->{ 'labels' };
+    my $server   = $args->{ 'server' };
+    my $count    = $args->{ 'count' };
+
+    $count = 1 if ! defined $count;
+
+    $count_id =  $self->clean_label( $count_id );
+
+    my $clean_labels = {};
+    if ( $labels ) {
+        foreach my $l ( sort keys %$labels ) {
+            $clean_labels->{ $self->clean_label( $l ) } = $self->clean_label( $labels->{$l} );
+        }
+    }
+
+    $clean_labels->{ident} = $self->clean_label( $Mail::Milter::Authentication::Config::IDENT );
+
+    eval{ $self->{prom}->set( 'authmilter_' . $count_id, $count, $clean_labels ); };
+    ## TODO catch and re-throw timeouts
+
+    return;
+}
+
 =method I<send( $server )>
 
 Send metrics to the parent server process.
@@ -179,7 +223,7 @@ sub master_metric_update {
     return;
 }
 
-=method I<child_handler( $server)>
+=method I<child_handler( $server )>
 
 Handle a metrics or http request in the child process.
 
@@ -228,6 +272,7 @@ sub child_handler {
         }
 
         if ( $request_uri eq '/metrics' ) {
+            $server->{'handler'}->{'_Handler'}->top_metrics_callback();
             $self->{prom}->set( 'authmilter_uptime_seconds_total', time - $self->{'start_time'}, { ident => $self->clean_label( $Mail::Milter::Authentication::Config::IDENT ) });
 
             print $socket "HTTP/1.0 200 OK\n";


### PR DESCRIPTION
DMARC Metrics for number of current/pending reports in the database.

 * Setup a new metrics callback, which is called when the metrics endpoint is about to be generated
 * Modify the register_metrics method to allow extra data to be set (to set gauge type)
 * Add methods to allow gauge values to be set from handlers
 * create DMARC metrics callback which counts reports in the database