### PR TITLE
No need for child communication sockets now

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Revision history for Mail-Milter-Authentication
 {{$NEXT}}
   - Improve language used internally
   - Core: Configurable SERVFAIL timeout with default
+  - Core: Avoid opening unnecessary sockets
 
 2.20200625.2 2020-06-25 04:34:45+00:00 UTC
   - DMARC: Option to redact some Reporting fields

--- a/lib/Mail/Milter/Authentication.pm
+++ b/lib/Mail/Milter/Authentication.pm
@@ -901,7 +901,6 @@ sub start($args) {
                 'ipv'   => '*',
                 'proto' => 'tcp',
             };
-            $srvargs{'child_communication'} = 1;
         }
         elsif ( $type eq 'unix' ) {
             _warn(
@@ -915,7 +914,6 @@ sub start($args) {
                 'port'  => $path,
                 'proto' => 'unix',
             };
-            $srvargs{'child_communication'} = 0;
 
             if ($umask) {
                 umask ( oct( $umask ) );
@@ -940,7 +938,6 @@ sub start($args) {
             'ipv'   => '*',
             'proto' => 'tcp',
         };
-        $srvargs{'child_communication'} = 1;
         _warn( 'Metrics available on ' . $metric_host . ':' . $config->{'metric_port'} );
         _warn( 'metric_host/metric_port are depricated, please use metric_connection/metric_umask instead' );
     }


### PR DESCRIPTION
This was needed in the days before Prometheus::Tiny::Shared, but no longer.