### PR TITLE
Sanitize: Fix domain/subdomain checking.

### DIFF
--- a/lib/Mail/Milter/Authentication/Handler/Sanitize.pm
+++ b/lib/Mail/Milter/Authentication/Handler/Sanitize.pm
@@ -33,24 +33,17 @@ sub is_hostname_mine {
 
     return 0 if ! defined $check_hostname;
 
-    my $hostname = $self->get_my_hostname();
-    my ($check_for) = $hostname =~ /^[^\.]+\.(.*)/;
-
     if ( exists( $config->{'hosts_to_remove'} ) ) {
         foreach my $remove_hostname ( @{ $config->{'hosts_to_remove'} } ) {
-            if (
-                substr( lc $check_hostname, ( 0 - length($remove_hostname) ) ) eq
-                lc $remove_hostname )
-            {
+            if ( $check_hostname =~ m/^(.*\.)?\Q${remove_hostname}\E$/i ) {
                 return 1;
             }
         }
     }
 
-    if (
-        substr( lc $check_hostname, ( 0 - length($check_for) ) ) eq
-        lc $check_for )
-    {
+    my $hostname = $self->get_my_hostname();
+    my ($check_for) = $hostname =~ /^[^\.]+\.(.*)/;
+    if ( $check_hostname =~ m/^(.*\.)?\Q${check_for}\E$/i ) {
         return 1;
     }
     return 0;

--- a/t/config/normal.smtp/authentication_milter.json
+++ b/t/config/normal.smtp/authentication_milter.json
@@ -73,7 +73,7 @@
         "!ReturnOK" : {},
         "Sanitize" : {
             "hosts_to_remove" : [
-                "test.module"
+                "module"
             ],
             "remove_headers" : "yes"
         }

--- a/t/config/normal/authentication_milter.json
+++ b/t/config/normal/authentication_milter.json
@@ -63,7 +63,7 @@
         "!ReturnOK" : {},
         "Sanitize" : {
             "hosts_to_remove" : [
-                "test.module"
+                "example.com"
             ],
             "remove_headers" : "yes"
         }

--- a/t/data/example/google_apps_good_sanitize.eml
+++ b/t/data/example/google_apps_good_sanitize.eml
@@ -34,6 +34,22 @@ X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
          Gb0MegXHP92U3iGZeZsEO1Gq9P6P44tp/v+09h9usq4OhBunjXojilYiB461BoBBYkGx
          MC7vok22L8D9ssU+z0H6VzSbD/B0tzPuLFQOKmoCVnim22SUpZHzNo05Ui3Bro43J3T0
          x9EA==
+Authentication-Results: notexample.com;
+    dkim-adsp=fail;
+    dkim=fail;
+    dkim=fail;
+    dmarc=fail;
+    iprev=fail;
+    spf=fail;
+    x-ptr=fail
+authentication-results: notmodule;
+    dkim-adsp=fail;
+    dkim=fail;
+    dkim=fail;
+    dmarc=fail;
+    iprev=fail;
+    spf=fail;
+    x-ptr=fail
 X-Gm-Message-State: ALoCoQk+WCmS7pcgC26VeCszzOVzmv40XekPP1BxHJ4oY6p8UbjDcdVNr8WFuchigs3toyPgqHDU
 MIME-Version: 1.0
 X-Received: by 10.194.175.39 with SMTP id bx7mr30495438wjc.22.1422156919049;
@@ -46,7 +62,16 @@ From: Marc Bradshaw <marc@marcbradshaw.net>
 To: marc@fastmail.com
 Content-Type: multipart/alternative; boundary=089e01493adaf9a7a9050d71b56f
 X-Received-Authentication-Results: (Received Authentication-Results header removed by test.module)
-    test.module;
+    example.com;
+    dkim-adsp=fail;
+    dkim=fail;
+    dkim=fail;
+    dmarc=fail;
+    iprev=fail;
+    spf=fail;
+    x-ptr=fail
+X-Received-Authentication-Results: (Received Authentication-Results header removed by test.module)
+    sub.example.com;
     dkim-adsp=fail;
     dkim=fail;
     dkim=fail;
@@ -64,16 +89,7 @@ X-Received-Authentication-Results: (Received Authentication-Results header remov
     spf=fail;
     x-ptr=fail
 X-Received-Authentication-Results: (Received Authentication-Results header removed by test.module)
-    test.module;
-    dkim-adsp=fail;
-    dkim=fail;
-    dkim=fail;
-    dmarc=fail;
-    iprev=fail;
-    spf=fail;
-    x-ptr=fail
-X-Received-Authentication-Results: (Received Authentication-Results header removed by test.module)
-    test.module;
+    module;
     dkim-adsp=fail;
     dkim=fail;
     dkim=fail;

--- a/t/data/example/google_apps_good_sanitize.smtp.eml
+++ b/t/data/example/google_apps_good_sanitize.smtp.eml
@@ -45,6 +45,22 @@ X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
          Gb0MegXHP92U3iGZeZsEO1Gq9P6P44tp/v+09h9usq4OhBunjXojilYiB461BoBBYkGx
          MC7vok22L8D9ssU+z0H6VzSbD/B0tzPuLFQOKmoCVnim22SUpZHzNo05Ui3Bro43J3T0
          x9EA==
+Authentication-Results: notexample.com;
+    dkim-adsp=fail;
+    dkim=fail;
+    dkim=fail;
+    dmarc=fail;
+    iprev=fail;
+    spf=fail;
+    x-ptr=fail
+authentication-results: notmodule;
+    dkim-adsp=fail;
+    dkim=fail;
+    dkim=fail;
+    dmarc=fail;
+    iprev=fail;
+    spf=fail;
+    x-ptr=fail
 X-Gm-Message-State: ALoCoQk+WCmS7pcgC26VeCszzOVzmv40XekPP1BxHJ4oY6p8UbjDcdVNr8WFuchigs3toyPgqHDU
 MIME-Version: 1.0
 X-Received: by 10.194.175.39 with SMTP id bx7mr30495438wjc.22.1422156919049;
@@ -57,7 +73,16 @@ From: Marc Bradshaw <marc@marcbradshaw.net>
 To: marc@fastmail.com
 Content-Type: multipart/alternative; boundary=089e01493adaf9a7a9050d71b56f
 X-Received-Authentication-Results: (Received Authentication-Results header removed by server.example.com)
-    test.module;
+    example.com;
+    dkim-adsp=fail;
+    dkim=fail;
+    dkim=fail;
+    dmarc=fail;
+    iprev=fail;
+    spf=fail;
+    x-ptr=fail
+X-Received-Authentication-Results: (Received Authentication-Results header removed by server.example.com)
+    sub.example.com;
     dkim-adsp=fail;
     dkim=fail;
     dkim=fail;
@@ -75,16 +100,7 @@ X-Received-Authentication-Results: (Received Authentication-Results header remov
     spf=fail;
     x-ptr=fail
 X-Received-Authentication-Results: (Received Authentication-Results header removed by server.example.com)
-    test.module;
-    dkim-adsp=fail;
-    dkim=fail;
-    dkim=fail;
-    dmarc=fail;
-    iprev=fail;
-    spf=fail;
-    x-ptr=fail
-X-Received-Authentication-Results: (Received Authentication-Results header removed by server.example.com)
-    test.module;
+    module;
     dkim-adsp=fail;
     dkim=fail;
     dkim=fail;

--- a/t/data/source/google_apps_good_sanitize.eml
+++ b/t/data/source/google_apps_good_sanitize.eml
@@ -19,7 +19,7 @@ X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
          Gb0MegXHP92U3iGZeZsEO1Gq9P6P44tp/v+09h9usq4OhBunjXojilYiB461BoBBYkGx
          MC7vok22L8D9ssU+z0H6VzSbD/B0tzPuLFQOKmoCVnim22SUpZHzNo05Ui3Bro43J3T0
          x9EA==
-Authentication-results: test.module;
+Authentication-Results: example.com;
     dkim-adsp=fail;
     dkim=fail;
     dkim=fail;
@@ -27,7 +27,23 @@ Authentication-results: test.module;
     iprev=fail;
     spf=fail;
     x-ptr=fail
-Authentication-Results: test.module;
+Authentication-Results: notexample.com;
+    dkim-adsp=fail;
+    dkim=fail;
+    dkim=fail;
+    dmarc=fail;
+    iprev=fail;
+    spf=fail;
+    x-ptr=fail
+Authentication-results: sub.example.com;
+    dkim-adsp=fail;
+    dkim=fail;
+    dkim=fail;
+    dmarc=fail;
+    iprev=fail;
+    spf=fail;
+    x-ptr=fail
+authentication-results: notmodule;
     dkim-adsp=fail;
     dkim=fail;
     dkim=fail;
@@ -43,7 +59,7 @@ authentication-results: test.module;
     iprev=fail;
     spf=fail;
     x-ptr=fail
-Authentication-Results: test.module;
+Authentication-Results: module;
     dkim-adsp=fail;
     dkim=fail;
     dkim=fail;


### PR DESCRIPTION
The existing code can incorrectly match suffixes. For example, a setting of "bar.example" would also match "foobar.example".
