### PR TITLE
Milter: Set SMFIP_HDR_LEADSPC to get exact whitespace from MTA.

### DIFF
--- a/lib/Mail/Milter/Authentication.pm
+++ b/lib/Mail/Milter/Authentication.pm
@@ -273,7 +273,9 @@ sub child_init_hook {
            $protocol &= ~SMFIP_NOBODY;
            $protocol &= ~SMFIP_NOHDRS;
            $protocol &= ~SMFIP_NOEOH;
+           $protocol |= SMFIP_HDR_LEADSPC;
         $self->{'protocol'} = $protocol;
+        $self->{'headers_include_space'} = 0;
 
         my $callback_flags = SMFI_CURR_ACTS|SMFIF_CHGBODY|SMFIF_QUARANTINE|SMFIF_SETSENDER;
         $self->{'callback_flags'} = $callback_flags;

--- a/lib/Mail/Milter/Authentication/Constants.pm
+++ b/lib/Mail/Milter/Authentication/Constants.pm
@@ -78,6 +78,7 @@ use constant SMFIP_NOBODY       => 0x10;
 use constant SMFIP_NOHDRS       => 0x20;
 use constant SMFIP_NOEOH        => 0x40;
 use constant SMFIP_NONE         => 0x7F;
+use constant SMFIP_HDR_LEADSPC  => 0x100000;
 
 use constant SMFIS_CONTINUE     => 100;
 use constant SMFIS_REJECT       => 101;
@@ -149,6 +150,7 @@ our @EXPORT = qw(
     SMFIP_NOHDRS
     SMFIP_NOEOH
     SMFIP_NONE
+    SMFIP_HDR_LEADSPC
     SMFIS_CONTINUE
     SMFIS_REJECT
     SMFIS_DISCARD

--- a/lib/Mail/Milter/Authentication/Protocol/Milter.pm
+++ b/lib/Mail/Milter/Authentication/Protocol/Milter.pm
@@ -86,7 +86,7 @@ sub milter_process_command {
     elsif ( $command eq SMFIC_HEADER ) {
         my $header = $self->milter_split_buffer( $buffer );
         if ( @$header == 1 ) { push @$header , q{}; };
-        my $original = join( ':', @$header );
+        my $original = join( $self->{'headers_include_space'} ? ':': ': ', @$header );
         push @$header, $original;
         $header->[1] =~ s/^\s+//;
         $header->[0] =~ s/^\s+//;
@@ -110,6 +110,7 @@ sub milter_process_command {
             pack('NNN', 2, $actions_reply, $protocol_reply)
         );
         undef $returncode;
+        $self->{'headers_include_space'} = ($protocol_reply & SMFIP_HDR_LEADSPC) != 0;
     }
     elsif ( $command eq SMFIC_RCPT ) {
         my $envrcpt = $self->milter_split_buffer( $buffer );
@@ -289,6 +290,7 @@ sub add_header {
     $self->write_packet( SMFIR_ADDHEADER,
         $header
         . "\0"
+        . ($self->{'headers_include_space'} ? ' ' : '')
         . $value
         . "\0"
     );
@@ -301,6 +303,7 @@ sub change_header {
         pack('N', $index)
         . $header
         . "\0"
+        . ($self->{'headers_include_space'} ? ' ' : '')
         . $value
         . "\0"
     );
@@ -312,6 +315,7 @@ sub insert_header {
         pack( 'N', $index )
         . $key
         . "\0"
+        . ($self->{'headers_include_space'} ? ' ' : '')
         . $value
         . "\0"
     );


### PR DESCRIPTION
I noticed this problem with DKIM-signed messages using simple header canonicalization, which would verify with dkimproxy-verify but not with authentication_milter. Would it be worth logging a warning if this feature is not provided by the MTA? If it is not provided, the only way we can verify a message with simple header canonicalization is by chance, if we happen to guess correctly whether there was a space after each colon in the original message headers.
