### PR TITLE
Pass ESMTP parameters to MAIL and RCPT callbacks

### DIFF
--- a/lib/Mail/Milter/Authentication/Handler.pm
+++ b/lib/Mail/Milter/Authentication/Handler.pm
@@ -741,7 +741,7 @@ sub top_envfrom_callback {
 
     # On MAILFROM
     #...
-    my ( $self, $env_from ) = @_;
+    my ( $self, $env_from, @params ) = @_;
     $self->status('envfrom');
     $self->dbgout( 'CALLBACK', 'EnvFrom', LOG_DEBUG );
     $self->set_return( $self->smfis_continue() );
@@ -763,7 +763,7 @@ sub top_envfrom_callback {
         foreach my $handler ( @$callbacks ) {
             $self->dbgout( 'CALLBACK', 'EnvFrom ' . $handler, LOG_DEBUG );
             my $start_time = $self->get_microseconds();
-            eval { $self->get_handler($handler)->envfrom_callback($env_from); };
+            eval { $self->get_handler($handler)->envfrom_callback($env_from, @params); };
             if ( my $error = $@ ) {
                 $self->handle_exception( $error );
                 $self->exit_on_close( 'Env From callback error ' . $error );
@@ -800,7 +800,7 @@ sub top_envrcpt_callback {
 
     # On RCPTTO
     #...
-    my ( $self, $env_to ) = @_;
+    my ( $self, $env_to, @params ) = @_;
     $self->status('envrcpt');
     $self->dbgout( 'CALLBACK', 'EnvRcpt', LOG_DEBUG );
     $self->set_return( $self->smfis_continue() );
@@ -816,7 +816,7 @@ sub top_envrcpt_callback {
         foreach my $handler ( @$callbacks ) {
             $self->dbgout( 'CALLBACK', 'EnvRcpt ' . $handler, LOG_DEBUG );
             my $start_time = $self->get_microseconds();
-            eval{ $self->get_handler($handler)->envrcpt_callback($env_to); };
+            eval{ $self->get_handler($handler)->envrcpt_callback($env_to, @params); };
             if ( my $error = $@ ) {
                 $self->handle_exception( $error );
                 $self->exit_on_close( 'Env Rcpt callback error ' . $error );

--- a/lib/Mail/Milter/Authentication/Protocol/SMTP.pm
+++ b/lib/Mail/Milter/Authentication/Protocol/SMTP.pm
@@ -222,6 +222,44 @@ sub command_param {
     return $p;
 }
 
+# Splits the given command parameter line into a list of separate
+# path (<foo@example.com>) and esmtp-param (KEYWORD=VALUE) strings.
+sub split_command_params {
+    my ( $line ) = @_;
+    $line =~ s/^\s+//;
+    my $path_end = find_path_end( $line ) || length( $line );
+    my $path = substr( $line, 0, $path_end );
+    $line = substr( $line, $path_end );
+    $line =~ s/^\s+//;
+    return ( $path, split( /\s+/, $line ) );
+}
+
+sub find_path_end {
+    my ( $input ) = @_;
+    my $len = length( $input );
+    my @qstack;
+    for ( my $i = 0; $i < $len; $i++ ) {
+        my $c = substr( $input, $i, 1 );
+        if ( @qstack && $c eq $qstack[-1] ) {
+            # end of a quoted string
+            pop @qstack;
+        } elsif ( $c eq '"' ) {
+            # start of a "" quoted string
+            push @qstack, '"';
+        } elsif ( $c eq '<' && ( !@qstack || $qstack[-1] eq '>' ) ) {
+            # start of a <> quoted string (possibly inside of another <>)
+            push @qstack, '>';
+        } elsif ( $c eq '\\' && @qstack ) {
+            # escaped character within a quoted string
+            $i++;
+        } elsif ( $c eq ' ' && !@qstack ) {
+            # found the end
+            return $i;
+        }
+    }
+    return ( @qstack ? undef : $len );
+}
+
 sub smtp_command_lhlo {
     my ( $self, $command ) = @_;
     my $smtp = $self->{'smtp'};
@@ -418,8 +456,7 @@ sub smtp_command_mailfrom {
         if ( $returncode == SMFIS_CONTINUE ) {
             my $envfrom = command_param( $command,10 );
             $smtp->{'mail_from'} = $envfrom;
-            $envfrom =~ s/ BODY=8BITMIME$//;
-            $returncode = $handler->top_envfrom_callback( $envfrom );
+            $returncode = $handler->top_envfrom_callback( split_command_params( $envfrom ) );
             if ( $returncode == SMFIS_CONTINUE ) {
                 $smtp->{'has_mail_from'} = 1;
                 print $socket "250 2.0.0 Ok\r\n";
@@ -481,7 +518,7 @@ sub smtp_command_rcptto {
     }
     my $envrcpt = command_param( $command,8 );
     push @{ $smtp->{'rcpt_to'} }, $envrcpt;
-    my $returncode = $handler->top_envrcpt_callback( $envrcpt );
+    my $returncode = $handler->top_envrcpt_callback( split_command_params( $envrcpt ) );
     if ( $returncode == SMFIS_CONTINUE ) {
         push @{ $smtp->{'lmtp_rcpt'} }, $envrcpt;
         print $socket "250 2.0.0 Ok\r\n";

--- a/t/AuthMilterTest.pm
+++ b/t/AuthMilterTest.pm
@@ -611,7 +611,7 @@ sub run_smtp_processing {
         'dest'   => 'google_apps_bad_space.smtp.eml',
         'ip'     => '74.125.82.171',
         'name'   => 'mail-we0-f171.google.com',
-        'from'   => 'marc@ marcbradshaw.net',
+        'from'   => '<marc@ marcbradshaw.net>',
         'to'     => 'marc@fastmail.com',
     });
     smtp_process({

--- a/t/data/example/google_apps_bad_space.smtp.eml
+++ b/t/data/example/google_apps_bad_space.smtp.eml
@@ -2,7 +2,7 @@ EHLO server.example.com
 XFORWARD HELO=mail-we0-f171.google.com
 XFORWARD ADDR=74.125.82.171
 XFORWARD NAME=mail-we0-f171.google.com
-MAIL FROM:marc@ marcbradshaw.net
+MAIL FROM:<marc@ marcbradshaw.net>
 RCPT TO:marc@fastmail.com
 DATA
 Received: from test.module (localhost [127.0.0.1])


### PR DESCRIPTION
The Milter protocol is already passing these parameters to the top callback, so the top callback just needs to pass them through to the handlers. The SMTP protocol required some parsing to split the parameters. This code roughly follows how Postfix parses SMTP commands.

I'm using this to get the domain to use for DKIM signing and ARC sealing from the ORCPT parameter of forwarded mail.
