### PR TITLE
Fix a warning

### DIFF
--- a/lib/Mail/Milter/Authentication/Tester.pm
+++ b/lib/Mail/Milter/Authentication/Tester.pm
@@ -419,8 +419,8 @@ sub send_smtp_packet {
         return 1;
     }
     else {
-        chomp $recv;
-        chomp $send;
+        $recv =~ s/\r?\n?$//;
+        $send =~ s/\r?\n?$//;
         warn "SMTP Send expected \"$expect\" received \"$recv\" when sending \"$send\"\n";
         return 0;
     }


### PR DESCRIPTION
We also need to strip \r from this line. This just makes the test output a little nicer.