### PR TITLE
Enforce orphan header

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Mail-Milter-Authentication
 
 {{$NEXT}}
+  - Core: Fix an error when appending Connection scope authentication-results
+    header parts which would cause processing child processes to crash.
 
 3.20210324 2021-03-24 06:00:40+00:00 UTC
   - DMARC: When a report fails to save move it to error state

--- a/lib/Mail/Milter/Authentication/Handler.pm
+++ b/lib/Mail/Milter/Authentication/Handler.pm
@@ -2593,6 +2593,7 @@ sub add_headers {
                 $are_string_headers = 1;
                 last;
             }
+            $header->orphan() if exists $header->{parent};
             $header_obj->add_child( $header );
         }
 


### PR DESCRIPTION
Fix an error when appending Connection scope authentication-results header parts which would cause processing child processes to crash.

Fixes #108 
