### PR TITLE
Make the RBLDNS config change mandatory

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 Revision history for Mail-Milter-Authentication
 
+  - RBLDNS: Config structure change is now mandatory
+
+  [UPDATED Config Items for RBLDNS]
+    RBLDNS config items MUST be moved under a new rbls key
+
 {{$NEXT}}
   - DNS: More consistent error logging on DNS lookup timeouts
   - RBLDNS: Config structure change

--- a/lib/Mail/Milter/Authentication/Handler/RBLDNS.pm
+++ b/lib/Mail/Milter/Authentication/Handler/RBLDNS.pm
@@ -50,8 +50,8 @@ sub register_metrics {
 
 sub setup_callback {
     my ($self) = @_;
-    my $config = $self->handler_config();
-    $config = $config->{rbls} if exists $config->{rbls};
+    my $handler_config = $self->handler_config();
+    $config = $handler_config->{rbls} // {};
     foreach my $rbl ( sort keys $config->%* ) {
         my $sanitize_header = $config->{$rbl}->{sanitize_header} // 'yes';
         $self->add_header_to_sanitize_list(lc $config->{$rbl}->{add_header}, $sanitize_header eq 'silent') if $config->{$rbl}->{add_header} && $sanitize_header ne 'no';
@@ -61,8 +61,8 @@ sub setup_callback {
 
 sub connect_callback {
     my ( $self, $hostname, $ip ) = @_;
-    my $config = $self->handler_config();
-    $config = $config->{rbls} if exists $config->{rbls};
+    my $handler_config = $self->handler_config();
+    $config = $handler_config->{rbls} // {};
 
     my @states;
 


### PR DESCRIPTION
To be merged sometime after the next release, which includes the optional version of this change.
This should allow folks to to migrate their configs.
I'll fix up the changes when I merge it back to master.