### PR TITLE
fix loginfo message

### DIFF
--- a/lib/Mail/Milter/Authentication/Protocol/Milter.pm
+++ b/lib/Mail/Milter/Authentication/Protocol/Milter.pm
@@ -203,7 +203,7 @@ sub milter_process_command {
                 }
                 else {
                     $handler->metric_count( 'mail_processed_total', { 'result' => 'deferred' } );
-                    $self->loginfo ( "SMTPDefer: $reject_reason" );
+                    $self->loginfo ( "SMTPDefer: $defer_reason" );
                     $self->write_packet( SMFIR_REPLYCODE,
                         $defer_reason
                         . "\0"


### PR DESCRIPTION
Use of uninitialized value $reject_reason in concatenation (.) or string at /usr/local/lib/perl5/site_perl/Mail/Milter/Authentication/Protocol/Milter.pm line 206