### PR TITLE
Log: Parse errors for AR headers, log the header not the error

### DIFF
--- a/lib/Mail/Milter/Authentication/Handler/Sanitize.pm
+++ b/lib/Mail/Milter/Authentication/Handler/Sanitize.pm
@@ -131,7 +131,7 @@ sub header_callback {
             };
             if ( my $error = $@ ) {
                 $self->handle_exception($error);
-                $self->log_error("Error parsing existing Authentication-Results header: $error");
+                $self->log_error("Error parsing existing Authentication-Results header: $value");
             }
 
             my $remove = 0;


### PR DESCRIPTION
When we encounter an existing Authentication-Results header that we cannot parse, log the header, not the error.
Logging the header is more useful in this case.