### PR TITLE
Fix DMARC handler config_file option

### DIFF
--- a/lib/Mail/Milter/Authentication.pm
+++ b/lib/Mail/Milter/Authentication.pm
@@ -162,6 +162,7 @@ sub pre_loop_hook($self,@) {
 
     # Load handlers
     my $config = get_config();
+    $self->{'config'} = $config;
     foreach my $name ( @{$config->{'load_handlers'}} ) {
         $self->load_handler( $name );
 
@@ -209,6 +210,7 @@ Hook which runs in parent before it forks children.
 sub run_n_children_hook($self,@) {
     # Load handlers
     my $config = get_config();
+    $self->{'config'} = $config;
     $self->{metric}->re_register_metrics;
     foreach my $name ( @{$config->{'load_handlers'}} ) {
 

--- a/lib/Mail/Milter/Authentication/Handler/DMARC.pm
+++ b/lib/Mail/Milter/Authentication/Handler/DMARC.pm
@@ -141,7 +141,7 @@ sub pre_loop_setup {
     my $dmarc = Mail::DMARC::PurePerl->new();
     my $config = $self->handler_config();
     if ( exists ( $config->{ 'config_file' } ) ) {
-        $self->log_error( 'DMARC config file does not exist' ) if ! exists $config->{ 'config_file' };
+        $self->log_error( 'DMARC config file does not exist' ) if ! -e $config->{ 'config_file' };
         $dmarc->config( $config->{ 'config_file' } );
     }
     my $psl = eval { $dmarc->get_public_suffix_list(); };
@@ -160,7 +160,7 @@ sub pre_fork_setup {
     my $dmarc = Mail::DMARC::PurePerl->new();
     my $config = $self->handler_config();
     if ( exists ( $config->{ 'config_file' } ) ) {
-        $self->log_error( 'DMARC config file does not exist' ) if ! exists $config->{ 'config_file' };
+        $self->log_error( 'DMARC config file does not exist' ) if ! -e $config->{ 'config_file' };
         $dmarc->config( $config->{ 'config_file' } );
     }
     my $check_time = 60*10; # Check no more often than every 10 minutes
@@ -675,7 +675,7 @@ sub new_dmarc_object {
     eval {
         $dmarc = Mail::DMARC::PurePerl->new();
         if ( exists ( $config->{ 'config_file' } ) ) {
-            $self->log_error( 'DMARC config file does not exist' ) if ! exists $config->{ 'config_file' };
+            $self->log_error( 'DMARC config file does not exist' ) if ! -e $config->{ 'config_file' };
             $dmarc->config( $config->{ 'config_file' } );
         }
         if ( $dmarc->can('set_resolver') ) {

--- a/lib/Mail/Milter/Authentication/Handler/DMARC.pm
+++ b/lib/Mail/Milter/Authentication/Handler/DMARC.pm
@@ -139,7 +139,7 @@ sub pre_loop_setup {
     my ( $self ) = @_;
     $PSL_CHECKED_TIME = time;
     my $dmarc = Mail::DMARC::PurePerl->new();
-    my $config = $self->{'config'};
+    my $config = $self->handler_config();
     if ( exists ( $config->{ 'config_file' } ) ) {
         $self->log_error( 'DMARC config file does not exist' ) if ! exists $config->{ 'config_file' };
         $dmarc->config( $config->{ 'config_file' } );
@@ -158,7 +158,7 @@ sub pre_fork_setup {
     my ( $self ) = @_;
     my $now = time;
     my $dmarc = Mail::DMARC::PurePerl->new();
-    my $config = $self->{'config'};
+    my $config = $self->handler_config();
     if ( exists ( $config->{ 'config_file' } ) ) {
         $self->log_error( 'DMARC config file does not exist' ) if ! exists $config->{ 'config_file' };
         $dmarc->config( $config->{ 'config_file' } );
@@ -669,7 +669,7 @@ sub get_dmarc_object {
 sub new_dmarc_object {
     my ( $self ) = @_;
 
-    my $config = $self->{'config'};
+    my $config = $self->handler_config();
     my $dmarc;
 
     eval {
@@ -682,7 +682,7 @@ sub new_dmarc_object {
             my $resolver = $self->get_object('resolver');
             $dmarc->set_resolver($resolver);
         }
-        if ( $config->{'debug'} && $config->{'logtoerr'} ) {
+        if ( $self->config()->{'debug'} && $self->config()->{'logtoerr'} ) {
             $dmarc->verbose(1);
         }
         $self->set_object('dmarc', $dmarc,1 );


### PR DESCRIPTION
Hello,

I had set config_file for my DMARC handler but when I was changing that file, it didn't seem to having any effect. I tracked the issue down to just small bug that was causing that setting to be looked up in the wrong place. I thought it would be a quick fix to just look it up via handler_config(), but it turned out that that function was not working in the early pre_loop_setup and pre_fork_setup callbacks because $self->{'thischild'}->{'config'} was not set yet. The 'config' property wasn't being set until child_init_hook().

I opted to go ahead and set 'config' on the Authentication object earlier, in the parent hooks. get_config() was already being called in those hooks so it seems reasonable to me to set the property there too. I did leave the calls to get_config() because that calls the external callback processor (if there is one). I don't know how that feature is used so I went the conservative route and kept those calls in place. I also set 'config' in each hook just in case the result from get_config() is a different object. I'd be happy to adjust any of this, just let me know.

Anyway, that allows config() and handler_config() to be used in the pre_loop_setup and pre_fork_setup callbacks, so that makes the DMARC config lookup fixes easy.

While I was there, I noticed that we were using exists() to check for the config file when we should have been using -e, so I fixed those too.

Thanks,
-- Aaron
