### PR TITLE
Build: Update 'make clean' to also remove t/tmp.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -114,6 +114,9 @@ my %WriteMakefileArgs = (
     "lib" => 0
   },
   "VERSION" => "3.20221121",
+  "clean" => {
+    "FILES" => "t/tmp"
+  },
   "test" => {
     "TESTS" => "t/*.t"
   }


### PR DESCRIPTION
I got fooled at one point when running the unit tests because the log files from previous runs were being appended to, so I thought this might help with that. With this change the t/tmp directory will be removed with 'make clean' and its variants.
