### PR TITLE
Fix get_client_proto for Net::Server>=2.011

### DIFF
--- a/lib/Mail/Milter/Authentication.pm
+++ b/lib/Mail/Milter/Authentication.pm
@@ -365,6 +365,10 @@ sub get_client_proto($self,@) {
         return $proto;
     }
 
+    if ($socket->isa("IO::Socket::IP")) {
+        return "TCP";
+    }
+
     if ($socket->isa("IO::Socket::INET")) {
         return "TCP";
     }


### PR DESCRIPTION
On my system, the latest release produces errors like this:

```
Could not determine connection protocol: Net::Server::Proto::TCP
Warning: Use of uninitialized value in string eq at /usr/share/perl5/vendor_perl/Mail/Milter/Authentication.pm line 361, <$read> line 103908.
Child process 2779945 shutting down due to fatal error: bad packet length 1195725856
```

This error seems to be a result of this change in Net::Server 2.011:

> - Default to IO::Socket::IP with continued fallback to IO::Socket::INET6

I don’t exactly consider myself a Perl expert, but it seems the issue can be fixed by simply checking for IO::Socket::IP in addition to INET and INET6, which is what this PR does.