### PR TITLE
Maint: switch from rdatastr to rdstring

### DIFF
--- a/lib/Mail/Milter/Authentication.pm
+++ b/lib/Mail/Milter/Authentication.pm
@@ -14,7 +14,7 @@ use Email::Simple::Creator;
 use Email::Simple;
 use ExtUtils::Installed;
 use Log::Dispatchouli;
-use Net::DNS::Resolver;
+use Net::DNS::Resolver 1.01;
 use Net::IP;
 use Proc::ProcessTable;
 use base 'Mail::Milter::Authentication::Net::ServerPatches';

--- a/lib/Mail/Milter/Authentication/Handler/AbusixDataFeed.pm
+++ b/lib/Mail/Milter/Authentication/Handler/AbusixDataFeed.pm
@@ -69,10 +69,10 @@ sub envfrom_callback {
         foreach my $rr ( $packet->answer ) {
             # We do not consider CNAMES here
             if ( $rr->type eq "PTR" ) {
-                my $rdatastr = $rr->rdatastr;
-                $rdatastr =~ s/\r//g;
-                $rdatastr =~ s/\n//g;
-                push @rdns, $rdatastr;
+                my $rdstring = $rr->rdatastr;
+                $rdstring =~ s/\r//g;
+                $rdstring =~ s/\n//g;
+                push @rdns, $rdstring;
             }
         }
     }

--- a/lib/Mail/Milter/Authentication/Handler/IPRev.pm
+++ b/lib/Mail/Milter/Authentication/Handler/IPRev.pm
@@ -71,11 +71,11 @@ sub connect_callback {
     if ($packet) {
         foreach my $rr ( $packet->answer ) {
             if ( $rr->type eq "CNAME" ) {
-                push @cname_hosts, $rr->rdatastr;
+                push @cname_hosts, $rr->rdstring;
                 push @error_list, 'Found CNAME in PTR response';
             }
             if ( $rr->type eq "PTR" ) {
-                $ptr_list->{ $rr->rdatastr } = [];
+                $ptr_list->{ $rr->rdstring } = [];
             }
         }
     }
@@ -95,7 +95,7 @@ sub connect_callback {
                 # Because anything more is probably busted anyway
                 #}
                 if ( $rr->type eq "PTR" ) {
-                    $ptr_list->{ $rr->rdatastr } = [];
+                    $ptr_list->{ $rr->rdstring } = [];
                 }
             }
         }
@@ -246,12 +246,12 @@ sub _address_for_domain {
     if ($packet) {
         foreach my $rr ( $packet->answer ) {
             if (  lc $rr->type eq 'cname' ) {
-                $cname = $rr->rdatastr;
+                $cname = $rr->rdstring;
                 # Multiple CNAMES are broken, but we don't check for that
                 # We just take the last one we found
             }
             if ( lc $rr->type eq lc $type ) {
-                push @ip_list, $rr->rdatastr;
+                push @ip_list, $rr->rdstring;
             }
         }
     }


### PR DESCRIPTION
Net::DNS has deprecated rdatastr in favour of rdstring