### PR TITLE
Make the DNS Timeouts caching configurable

### DIFF
--- a/bin/authentication_milter
+++ b/bin/authentication_milter
@@ -327,6 +327,7 @@ __END__
     ],
     "dns_timeout"           : 10,                       | Timeout in seconds for DNS lookups
     "dns_retry"             : 2,                        | Number of times a lookup will retry per call
+    "cache_dns_timeouts"    : 1,                        | By default org domains, that result in a DNS timeout are cached
     "dns_servfail_timeout"  : 1000000,                  | How long microseconds a SERVFAIL can take before being considered a timeout
                                                         |     by the internal resolver
 

--- a/lib/Mail/Milter/Authentication/Config.pm
+++ b/lib/Mail/Milter/Authentication/Config.pm
@@ -74,6 +74,7 @@ sub default_config {
         'addheader_timeout'               => 30,
         'dns_timeout'                     => 10,
         'dns_retry'                       => 2,
+        'cache_dns_timeouts'              => 1,
         'tempfail_on_error'               => '1',
         'tempfail_on_error_authenticated' => '0',
         'tempfail_on_error_local'         => '0',

--- a/lib/Mail/Milter/Authentication/Handler.pm
+++ b/lib/Mail/Milter/Authentication/Handler.pm
@@ -1552,6 +1552,7 @@ sub get_object {
                 $args{udp_timeout} = $config->{'dns_timeout'}   || 8;
                 $args{tcp_timeout} = $config->{'dns_timeout'}   || 8;
                 $args{retry}       = $config->{'dns_retry'}     || 2;
+                $args{cache_dns_timeouts} = $config->{'cache_dns_timeouts'} // 1;
                 $args{nameservers} = $config->{'dns_resolvers'} if $config->{'dns_resolvers'} && $config->{'dns_resolvers'}->@*;
                 $object = Mail::Milter::Authentication::Resolver->new(%args);
                 $object->udppacketsize(1240);

--- a/share/authentication_milter.json
+++ b/share/authentication_milter.json
@@ -22,6 +22,7 @@
     "content_timeout"       : 300,
     "dns_timeout"           : 10,
     "dns_retry"             : 2,
+    "cache_dns_timeouts"    : 1,
 
     "tempfail_on_error"               : "1",
     "tempfail_on_error_authenticated" : "0",


### PR DESCRIPTION
This PR adds a config option to allow disabling the caching of domains, which timed out during a DNS query. By default the option is enabled to preserve the current behaviour. Setting the option to 0 disables the cache and the query will be sent the the DNS resolver each time, regardless of previous timeouts.