### PR TITLE
Use canonical string representation for IPv6 addresses

### DIFF
--- a/lib/Mail/Milter/Authentication/Handler.pm
+++ b/lib/Mail/Milter/Authentication/Handler.pm
@@ -607,7 +607,7 @@ sub remap_connect_callback {
         }
         else {
             $ip = $ip_remap->{ip};
-            $self->dbgout( 'RemappedConnect', $self->{'raw_ip_object'}->ip() . ' > ' . $ip->ip(), LOG_DEBUG );
+            $self->dbgout( 'RemappedConnect', $self->{'raw_ip_object'}->short() . ' > ' . $ip->short(), LOG_DEBUG );
        }
     }
     $self->{'ip_object'} = $ip;
@@ -656,7 +656,7 @@ sub top_connect_callback {
             $self->set_alarm( $timeout );
         }
 
-        $self->dbgout( 'ConnectFrom', $ip->ip(), LOG_DEBUG );
+        $self->dbgout( 'ConnectFrom', $ip->short(), LOG_DEBUG );
 
         my $callbacks = $self->get_callbacks( 'connect' );
         foreach my $handler ( @$callbacks ) {
@@ -706,7 +706,7 @@ sub remap_helo_callback {
             if ( $self->{'ip_object'}->ip() ne $ip_remap->{ip}->ip() ) {
                 # The mapped IP has been changed based on the HELO host received
                 $self->{'ip_object'} = $ip;
-                $self->dbgout( 'RemappedConnectHELO', $self->{'ip_object'}->ip() . ' > ' . $ip->ip(), LOG_DEBUG );
+                $self->dbgout( 'RemappedConnectHELO', $self->{'ip_object'}->short() . ' > ' . $ip->short(), LOG_DEBUG );
             }
             $helo_host = $ip_remap->{helo};
             $self->dbgout( 'RemappedHELO', $self->{'raw_helo_name'} . ' > ' . $helo_host, LOG_DEBUG );
@@ -2081,7 +2081,7 @@ Return the ip address of the current connection.
 sub ip_address {
     my ($self) = @_;
     my $top_handler = $self->get_top_handler();
-    return $top_handler->{'ip_object'}->ip();
+    return $top_handler->{'ip_object'}->short();
 }
 
 

--- a/lib/Mail/Milter/Authentication/Handler/LocalIP.pm
+++ b/lib/Mail/Milter/Authentication/Handler/LocalIP.pm
@@ -20,7 +20,7 @@ sub grafana_rows {
 
 sub is_local_ip_address {
     my ( $self, $ip ) = @_;
-    my $ip_address = $ip->ip();
+    my $ip_address = $ip->short();
     my $ip_type  = $ip->iptype();
     my $type_map = {
         'PRIVATE'              => 1,

--- a/lib/Mail/Milter/Authentication/Handler/Logger.pm
+++ b/lib/Mail/Milter/Authentication/Handler/Logger.pm
@@ -28,7 +28,7 @@ sub connect_callback {
     my $config = $self->handler_config();
     return if ! $config->{connect};
     $self->dbgout( 'Logger', 'Connection host: ' . $hostname, LOG_INFO );
-    $self->dbgout( 'Logger', 'Connection IP: ' . $ip->ip(), LOG_INFO );
+    $self->dbgout( 'Logger', 'Connection IP: ' . $ip->short(), LOG_INFO );
     return;
 }
 

--- a/lib/Mail/Milter/Authentication/Protocol/SMTP.pm
+++ b/lib/Mail/Milter/Authentication/Protocol/SMTP.pm
@@ -449,7 +449,7 @@ sub smtp_command_mailfrom {
     $handler->remap_connect_callback( $host, Net::IP->new( $ip ) );
     $handler->remap_helo_callback( $helo );
 
-    $self->logdebug( "Inbound IP Address " . $handler->{'ip_object'}->ip() );
+    $self->logdebug( "Inbound IP Address " . $handler->{'ip_object'}->short() );
     $returncode = $handler->top_connect_callback( $host, $handler->{'ip_object'} );
     if ( $returncode == SMFIS_CONTINUE ) {
         $returncode = $handler->top_helo_callback( $handler->{'helo_name'} );


### PR DESCRIPTION
Net::IP::ip returns the expanded representation for IPv6 addresses (from ip_expand_address), whereas Net::IP::short returns the compressed representation (from ip_compress_address) recommended by RFC 5952. Per section 4, "The recommendation in this section SHOULD be followed by systems when generating an address to be represented as text."[1]

Net::IP::ip and Net::IP::short return the same value for single IPv4 addresses, however they may return different values for IPv4 prefixes. The code affected by this change only deals with single addresses so there is no change to the representation of IPv4 addresses.

[1] https://datatracker.ietf.org/doc/html/rfc5952#section-4