### PR TITLE
LocalIP: Add option to ignore list of IPs or CIDR ranges

### DIFF
--- a/lib/Mail/Milter/Authentication/Handler/LocalIP.pm
+++ b/lib/Mail/Milter/Authentication/Handler/LocalIP.pm
@@ -6,9 +6,12 @@ use Mail::Milter::Authentication::Pragmas;
 # ABSTRACT: Handler class for Local IP Connections
 # VERSION
 use base 'Mail::Milter::Authentication::Handler';
+use Net::IP;
 
 sub default_config {
-    return {};
+    return {
+        'ignore_local_ip_list' => [],
+    };
 }
 
 sub grafana_rows {
@@ -44,6 +47,27 @@ sub is_local_ip_address {
         'UNIQUE-LOCAL-UNICAST' => 1,
         'LINK-LOCAL-UNICAST'   => 1,
     };
+    my $config = $self->handler_config();
+    if ( exists $config->{'ignore_local_ip_list'} ) {
+        foreach my $ignore_ip ( @{ $config->{'ignore_local_ip_list'}  } ) {
+            my $ignore_ip_obj = Net::IP->new($ignore_ip);
+            if ( !$ignore_ip_obj ) {
+                $self->log_error( 'LocalIP: Could not parse ignore IP '.$ignore_ip );
+            }
+            else {
+                my $is_overlap = $ip->overlaps($ignore_ip_obj) || 0;
+                if (
+                    $is_overlap == $IP_A_IN_B_OVERLAP
+                    || $is_overlap == $IP_B_IN_A_OVERLAP     # Should never happen
+                    || $is_overlap == $IP_PARTIAL_OVERLAP    # Should never happen
+                    || $is_overlap == $IP_IDENTICAL
+                )
+                {
+                    return 0;
+                }
+            }
+        }
+    }
     $self->dbgout( 'IPAddress', "Address $ip_address detected as type $ip_type", LOG_DEBUG );
     return $type_map->{ $ip_type } || 0;
 }
@@ -83,3 +107,13 @@ Detect a Local IP address and act accordingly.
 
 No configuration options exist for this handler.
 
+=head1 CONFIGURATION
+
+        "LocalIP" : {                                   | Config the LocalIP Module
+                                                        | Check for LocalIP Addresses
+            "ignore_local_ip_list" : [                  | List of IP Addresses to treat as non-local
+                "127.0.0.1",                            | CIDR Ranges are valid syntax
+                "10.0.0.0/24"                           | This is useful, for test environments where non-local IPs aren't available
+                "fe80::/10",
+            ],
+        },

--- a/t/04-unit-handler-localip.t
+++ b/t/04-unit-handler-localip.t
@@ -21,13 +21,18 @@ my $tester = Mail::Milter::Authentication::Tester::HandlerTester->new({
     'prefix'   => $basedir . 't/config/handler/etc',
     'zonedata' => '',
     'handler_config' => {
-        'LocalIP' => {},
+        'LocalIP' => {
+            'ignore_local_ip_list' => [
+                '10.0.0.0/24',
+                '10.1.0.5'
+            ],
+        },
     },
 });
 
 subtest 'config' => sub {
     my $config = $tester->{ 'authmilter' }->{ 'handler' }->{ 'LocalIP' }->default_config();
-    is_deeply( $config, {}, 'Returns correct config' );
+    is_deeply( $config, { 'ignore_local_ip_list' => [] }, 'Returns correct config' );
 };
 
 subtest 'metrics' => sub {
@@ -61,6 +66,12 @@ subtest 'Private IPv6 Ranges' => sub {
 
 subtest 'Global IPv6 Ranges' => sub {
     test( $tester, { 'name' => 'Global', 'result' => '', 'ip' => '2400:8900::f03c:91ff:fe6e:84c7' });
+};
+
+subtest 'Ignore Local IP' => sub {
+    test( $tester, { 'name' => '10.0.0.5', 'result' => '', 'ip' => '10.0.0.5' });
+    test( $tester, { 'name' => '10.1.0.5', 'result' => '', 'ip' => '10.1.0.5' });
+    test( $tester, { 'name' => '10.1.0.6', 'result' => 'pass', 'ip' => '10.1.0.6' });
 };
 
 #test( $tester, { 'name' => '', 'result' => 'pass', 'ip' => '' });


### PR DESCRIPTION
Being able to dedicate some IPs or ranges to be treated as public is useful ina test environment where public IPs are not available.