### PR TITLE
Key the DNS timeout cache on a public suffix lookup (fixes #180)

### DIFF
--- a/lib/Mail/Milter/Authentication/Resolver.pm
+++ b/lib/Mail/Milter/Authentication/Resolver.pm
@@ -6,6 +6,7 @@ use Mail::Milter::Authentication::Pragmas;
 # ABSTRACT: DNS Recolver methods
 # VERSION
 use base 'Net::DNS::Resolver';
+use Domain::PublicSuffix;
 use Scalar::Util qw{ weaken };
 use Time::HiRes qw{ ualarm gettimeofday };
 
@@ -42,6 +43,21 @@ sub _get_microseconds {
     return ( ( $seconds * 1000000 ) + $microseconds );
 }
 
+sub _get_public_suffix_object {
+    my ( $self ) = @_;
+    # Parsing the suffix list is expensive, build it once per resolver.
+    return $self->{ _public_suffix } //= do {
+        my $handler = $self->{_handler};
+        my $config = $handler ? $handler->config() : {};
+        # Prefer a locally maintained suffix list when one is configured,
+        # otherwise fall back to the copy bundled with Domain::PublicSuffix.
+        my $data_file = $config->{'public_suffix_list'};
+        Domain::PublicSuffix->new(
+            $data_file && -r $data_file ? { data_file => $data_file } : ()
+        );
+    };
+}
+
 sub _do { ## no critic
     my $self = shift;
     my $what = shift;
@@ -54,11 +70,17 @@ sub _do { ## no critic
     my $domain = $_[0];
     my $org_domain = $_[0];
     my $query = $_[1];
-    if ( $handler->is_handler_loaded( 'DMARC' ) ) {
-        my $dmarc_object = $handler->get_handler('DMARC')->get_dmarc_object();
-        $org_domain = eval{ $dmarc_object->get_organizational_domain( $org_domain ) };
-        $handler->handle_exception( $@ );
-    }
+    # The timeout cache is keyed on the organizational domain so that one
+    # timeout suppresses lookups for every name beneath it. Resolve that from
+    # the public suffix list rather than via Mail::DMARC: 2.x resolves the
+    # organizational domain with a DNS tree walk (RFC 9989), and since this
+    # method wraps every DNS query, that call recursed into itself without
+    # bound. A public suffix lookup is pure computation and cannot recurse.
+    $org_domain = eval{ $self->_get_public_suffix_object->get_root_domain( $domain ) };
+    $handler->handle_exception( $@ );
+    # get_root_domain returns undef for bare TLDs and unlisted suffixes; fall
+    # back to the queried domain so the cache below is not keyed on undef.
+    $org_domain //= $domain;
 
     # If we have a 'cached' timeout for this org domain then return
     if ( $self->{ _timedout }->{ $org_domain } ) {


### PR DESCRIPTION
Fixes #180.

### The problem

`Resolver::_do` wraps every DNS `send`/`query`/`search`, and calls `get_organizational_domain` on each one to key its timeout cache:

```perl
$org_domain = eval{ $dmarc_object->get_organizational_domain( $org_domain ) };
```

That was written when `get_organizational_domain` answered from the public suffix list without touching DNS. Since `Mail::DMARC` implemented RFC 9989, it resolves the organizational domain with a DNS tree walk instead — so the call re-enters `_do`, which calls it again, without bound. 

Also seen with `Mail::DMARC` 2.20260724 on Perl 5.36, so it isn't specific to the version or platform in the original report.

### The fix

Resolve the organizational domain with `Domain::PublicSuffix` rather than through `Mail::DMARC`.

A public suffix lookup is pure computation, so it cannot recurse. It also preserves the cache semantics: every lookup — including those made during a tree walk — keys on the organizational domain, so one timeout still suppresses queries for all names beneath it. `_do` no longer references the DMARC handler at all.

The suffix list defaults to the copy bundled with `Domain::PublicSuffix`, and a `public_suffix_list` config key points at a locally maintained file for deployments that already refresh one.

### Alternative considered

A re-entrancy flag around the existing `get_organizational_domain` call is a smaller diff. I implemented that first and rejected it: during a tree walk the nested lookups fall back to keying on the queried name, so only the exact-match level hits the cache and every subdomain-level query still goes to DNS — it fixes the recursion but quietly weakens the timeout cache. 

### Testing

Verified in production against `Mail::DMARC` 2.20260724 — the version that was recursing. Stable, no recursion warnings, mail authenticated end to end.

